### PR TITLE
fix(QuestHandler): use CanToggleWarModeInArea instead

### DIFF
--- a/APR-Core/QuestHandler.lua
+++ b/APR-Core/QuestHandler.lua
@@ -1579,7 +1579,7 @@ local function APR_PrintQStep()
 						APR.QuestList.QuestFrames[LineNr]:SetWidth(410)
 					end
 				end
-				if (C_PvP.IsWarModeDesired() == false and C_PvP.CanToggleWarMode(toggle) == true) then
+				if (C_PvP.IsWarModeDesired() == false and C_PvP.CanToggleWarModeInArea()) then
 					C_PvP.ToggleWarMode()
 					APR.BookingList["PrintQStep"] = 1
 				end


### PR DESCRIPTION
`toggle` is never set. The original function expects a boolean to indicate if you can switch the warmode state to that of the boolean. ie true = on, false = off. Just use the `InArea` variant for simplicity.